### PR TITLE
[feat] 메모 Edit 화면, 카테고리 선택 기능 추가 

### DIFF
--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/MemoEditActivity.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/MemoEditActivity.kt
@@ -2,16 +2,18 @@ package com.memo_zi.presentation.ui.memo
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
+import androidx.activity.viewModels
 import androidx.core.widget.addTextChangedListener
-import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.memo_zi.R
 import com.memo_zi.databinding.ActivityMemoEditBinding
+import com.memo_zi.presentation.ui.memo.adapter.MemoCategorySelectAdapter
 import com.memo_zi.util.binding.BindingActivity
 
 
 class MemoEditActivity : BindingActivity<ActivityMemoEditBinding>(R.layout.activity_memo_edit) {
-
+    private val viewModel by viewModels<MemoViewModel>()
+    private lateinit var categoryAdapter: MemoCategorySelectAdapter
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initLayout()
@@ -19,6 +21,7 @@ class MemoEditActivity : BindingActivity<ActivityMemoEditBinding>(R.layout.activ
 
     private fun initLayout() {
         setupButton()
+        initAdapter()
         setButtonEnable()
     }
 
@@ -46,18 +49,26 @@ class MemoEditActivity : BindingActivity<ActivityMemoEditBinding>(R.layout.activ
         }
     }
 
-    private fun setBottomSheet() {
-        val bottomSheetView =
-            layoutInflater.inflate(R.layout.bottom_sheet_memo_category_select, null)
-        val bottomSheetDialog = BottomSheetDialog(this@MemoEditActivity)
-        val offsetFromTop = MARGIN_BOTTOM_SHEET
-        (bottomSheetDialog as? BottomSheetDialog)?.behavior?.apply {
-            isFitToContents = false
-            expandedOffset = offsetFromTop
-            state = BottomSheetBehavior.STATE_EXPANDED
+    private fun initAdapter() {
+        categoryAdapter = MemoCategorySelectAdapter(this)
+        binding.includeBottomSheetMemoEdit.rcvMemoCategorySelect.adapter = categoryAdapter
+
+        viewModel.memoList.observe(this) { categoryList ->
+            categoryAdapter.setCategoryList(categoryList)
         }
-        bottomSheetDialog.setContentView(bottomSheetView)
-        bottomSheetDialog.show()
+    }
+
+    private fun setBottomSheet() {
+        binding.layoutMemoEditCategorySelectDim.visibility = View.VISIBLE
+        binding.layoutMemoEditBottomSheet.visibility = View.VISIBLE
+        binding.includeBottomSheetMemoEdit.ibMemoCategorySelectCancel.setOnClickListener {
+            binding.layoutMemoEditCategorySelectDim.visibility = View.INVISIBLE
+            binding.layoutMemoEditBottomSheet.visibility = View.INVISIBLE
+        }
+    }
+
+    private fun test() {
+
     }
 
 

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/MemoEditActivity.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/MemoEditActivity.kt
@@ -3,14 +3,12 @@ package com.memo_zi.presentation.ui.memo
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.core.widget.addTextChangedListener
 import com.memo_zi.R
 import com.memo_zi.databinding.ActivityMemoEditBinding
 import com.memo_zi.presentation.ui.memo.adapter.MemoCategorySelectAdapter
 import com.memo_zi.util.binding.BindingActivity
-
 
 class MemoEditActivity : BindingActivity<ActivityMemoEditBinding>(R.layout.activity_memo_edit) {
     private val viewModel by viewModels<MemoViewModel>()

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/MemoEditActivity.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/MemoEditActivity.kt
@@ -3,6 +3,7 @@ package com.memo_zi.presentation.ui.memo
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.core.widget.addTextChangedListener
 import com.memo_zi.R
@@ -56,11 +57,23 @@ class MemoEditActivity : BindingActivity<ActivityMemoEditBinding>(R.layout.activ
     }
 
     private fun initAdapter() {
-        categoryAdapter = MemoCategorySelectAdapter(this, selectedCategory = selectCategory)
+        categoryAdapter = MemoCategorySelectAdapter(
+            this,
+            selectedCategory = selectCategory,
+            itemClick = createCategorySelectListener()
+        )
         binding.includeBottomSheetMemoEdit.rcvMemoCategorySelect.adapter = categoryAdapter
 
         viewModel.categoryList.observe(this) { categoryList ->
             categoryAdapter.setCategoryList(categoryList)
+        }
+    }
+
+    private fun createCategorySelectListener(): (String) -> Unit {
+        return { selectedCategory ->
+            selectCategory = selectedCategory
+            binding.tvMemoEditCategoryName.text = selectCategory
+            initAdapter()
         }
     }
 
@@ -72,11 +85,6 @@ class MemoEditActivity : BindingActivity<ActivityMemoEditBinding>(R.layout.activ
             binding.layoutMemoEditBottomSheet.visibility = View.INVISIBLE
         }
     }
-
-    private fun test() {
-
-    }
-
 
     private fun setButtonEnable() {
         binding.run {

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/MemoEditActivity.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/MemoEditActivity.kt
@@ -13,6 +13,7 @@ import com.memo_zi.util.binding.BindingActivity
 
 class MemoEditActivity : BindingActivity<ActivityMemoEditBinding>(R.layout.activity_memo_edit) {
     private val viewModel by viewModels<MemoViewModel>()
+    private var selectCategory = "투두리스트"
     private lateinit var categoryAdapter: MemoCategorySelectAdapter
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,6 +24,11 @@ class MemoEditActivity : BindingActivity<ActivityMemoEditBinding>(R.layout.activ
         setupButton()
         initAdapter()
         setButtonEnable()
+    }
+
+    private fun setupCategoryTitle(text: String) {
+        selectCategory = text
+        binding.tvMemoEditCategoryName.text = selectCategory
     }
 
     private fun setupButton() {
@@ -50,10 +56,10 @@ class MemoEditActivity : BindingActivity<ActivityMemoEditBinding>(R.layout.activ
     }
 
     private fun initAdapter() {
-        categoryAdapter = MemoCategorySelectAdapter(this)
+        categoryAdapter = MemoCategorySelectAdapter(this, selectedCategory = selectCategory)
         binding.includeBottomSheetMemoEdit.rcvMemoCategorySelect.adapter = categoryAdapter
 
-        viewModel.memoList.observe(this) { categoryList ->
+        viewModel.categoryList.observe(this) { categoryList ->
             categoryAdapter.setCategoryList(categoryList)
         }
     }

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectAdapter.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectAdapter.kt
@@ -8,7 +8,8 @@ import com.memo_zi.data.model.MemoItem
 import com.memo_zi.databinding.ItemMemoCategorySelectBinding
 
 class MemoCategorySelectAdapter(
-    private val context: Context
+    private val context: Context,
+    private val selectedCategory: String
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private val inflater by lazy { LayoutInflater.from(context) }
     private val categoryList = mutableListOf<MemoItem>()
@@ -17,7 +18,7 @@ class MemoCategorySelectAdapter(
         return MemoCategorySelectViewHolder(
             ItemMemoCategorySelectBinding.inflate(
                 inflater, parent, false
-            )
+            ), selectedCategory
         )
     }
 

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectAdapter.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectAdapter.kt
@@ -9,7 +9,8 @@ import com.memo_zi.databinding.ItemMemoCategorySelectBinding
 
 class MemoCategorySelectAdapter(
     private val context: Context,
-    private val selectedCategory: String
+    private val selectedCategory: String,
+    private val itemClick: (String) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private val inflater by lazy { LayoutInflater.from(context) }
     private val categoryList = mutableListOf<MemoItem>()
@@ -24,7 +25,10 @@ class MemoCategorySelectAdapter(
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
-            is MemoCategorySelectViewHolder -> holder.onBind(categoryList[position] as MemoItem.Category)
+            is MemoCategorySelectViewHolder -> holder.onBind(
+                categoryList[position] as MemoItem.Category,
+                itemClick
+            )
         }
     }
 

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectAdapter.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectAdapter.kt
@@ -1,0 +1,38 @@
+package com.memo_zi.presentation.ui.memo.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.memo_zi.data.model.MemoItem
+import com.memo_zi.databinding.ItemMemoCategorySelectBinding
+
+class MemoCategorySelectAdapter(
+    private val context: Context
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private val inflater by lazy { LayoutInflater.from(context) }
+    private val categoryList = mutableListOf<MemoItem>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return MemoCategorySelectViewHolder(
+            ItemMemoCategorySelectBinding.inflate(
+                inflater, parent, false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is MemoCategorySelectViewHolder -> holder.onBind(categoryList[position] as MemoItem.Category)
+        }
+    }
+
+    override fun getItemCount(): Int = categoryList.size
+
+    fun setCategoryList(dataList: List<MemoItem>) {
+        categoryList.clear()
+        categoryList.addAll(dataList)
+        notifyDataSetChanged()
+    }
+
+}

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectViewHolder.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectViewHolder.kt
@@ -3,13 +3,19 @@ package com.memo_zi.presentation.ui.memo.adapter
 import androidx.recyclerview.widget.RecyclerView
 import com.memo_zi.data.model.MemoItem
 import com.memo_zi.databinding.ItemMemoCategorySelectBinding
+import com.memo_zi.util.component.TextviewSetting
 
-class MemoCategorySelectViewHolder(private val binding: ItemMemoCategorySelectBinding) :
+class MemoCategorySelectViewHolder(
+    private val binding: ItemMemoCategorySelectBinding,
+    private val selectedCategory: String
+) :
     RecyclerView.ViewHolder(binding.root) {
 
     fun onBind(categoryData: MemoItem.Category) {
         binding.run {
-            tvMemoSelectCategoryTitle.text = categoryData.title
+            if (selectedCategory == categoryData.title) {
+                tvMemoSelectCategoryTitle.text = TextviewSetting().setTextBold(categoryData.title)
+            } else tvMemoSelectCategoryTitle.text = categoryData.title
         }
     }
 }

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectViewHolder.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectViewHolder.kt
@@ -1,0 +1,15 @@
+package com.memo_zi.presentation.ui.memo.adapter
+
+import androidx.recyclerview.widget.RecyclerView
+import com.memo_zi.data.model.MemoItem
+import com.memo_zi.databinding.ItemMemoCategorySelectBinding
+
+class MemoCategorySelectViewHolder(private val binding: ItemMemoCategorySelectBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun onBind(categoryData: MemoItem.Category) {
+        binding.run {
+            tvMemoSelectCategoryTitle.text = categoryData.title
+        }
+    }
+}

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectViewHolder.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectViewHolder.kt
@@ -4,7 +4,6 @@ import android.graphics.Typeface
 import androidx.recyclerview.widget.RecyclerView
 import com.memo_zi.data.model.MemoItem
 import com.memo_zi.databinding.ItemMemoCategorySelectBinding
-import com.memo_zi.util.component.TextviewSetting
 
 class MemoCategorySelectViewHolder(
     private val binding: ItemMemoCategorySelectBinding,
@@ -16,10 +15,8 @@ class MemoCategorySelectViewHolder(
         binding.run {
             tvMemoSelectCategoryTitle.text = categoryData.title
             if (selectedCategory == categoryData.title) {
-                // 타이틀을 Bold로 설정
                 tvMemoSelectCategoryTitle.setTypeface(null, Typeface.BOLD)
             } else {
-                // 타이틀을 기본 스타일로 설정
                 tvMemoSelectCategoryTitle.setTypeface(null, Typeface.NORMAL)
             }
             binding.layoutMemoSelectCategory.setOnClickListener {

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectViewHolder.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoCategorySelectViewHolder.kt
@@ -1,5 +1,6 @@
 package com.memo_zi.presentation.ui.memo.adapter
 
+import android.graphics.Typeface
 import androidx.recyclerview.widget.RecyclerView
 import com.memo_zi.data.model.MemoItem
 import com.memo_zi.databinding.ItemMemoCategorySelectBinding
@@ -11,11 +12,19 @@ class MemoCategorySelectViewHolder(
 ) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun onBind(categoryData: MemoItem.Category) {
+    fun onBind(categoryData: MemoItem.Category, itemClick: (String) -> Unit) {
         binding.run {
+            tvMemoSelectCategoryTitle.text = categoryData.title
             if (selectedCategory == categoryData.title) {
-                tvMemoSelectCategoryTitle.text = TextviewSetting().setTextBold(categoryData.title)
-            } else tvMemoSelectCategoryTitle.text = categoryData.title
+                // 타이틀을 Bold로 설정
+                tvMemoSelectCategoryTitle.setTypeface(null, Typeface.BOLD)
+            } else {
+                // 타이틀을 기본 스타일로 설정
+                tvMemoSelectCategoryTitle.setTypeface(null, Typeface.NORMAL)
+            }
+            binding.layoutMemoSelectCategory.setOnClickListener {
+                itemClick(binding.tvMemoSelectCategoryTitle.text.toString())
+            }
         }
     }
 }

--- a/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoListViewHolder.kt
+++ b/MEMO-Zi/app/src/main/java/com/memo_zi/presentation/ui/memo/adapter/MemoListViewHolder.kt
@@ -1,7 +1,6 @@
 package com.memo_zi.presentation.ui.memo.adapter
 
 import androidx.recyclerview.widget.RecyclerView
-
 import com.memo_zi.data.model.MemoItem
 import com.memo_zi.databinding.ItemMemoListAllBinding
 

--- a/MEMO-Zi/app/src/main/res/layout/activity_memo_edit.xml
+++ b/MEMO-Zi/app/src/main/res/layout/activity_memo_edit.xml
@@ -8,8 +8,19 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_memo_edit_category_select_dim"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/black_20"
+            android:elevation="3dp"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toTopOf="@id/layout_memo_edit_bottom_sheet"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/gl_start_edit"
@@ -223,5 +234,17 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/btn_memo_edit_bold" />
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_memo_edit_bottom_sheet"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="98dp"
+            android:visibility="invisible"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <include
+                android:id="@+id/include_bottom_sheet_memo_edit"
+                layout="@layout/bottom_sheet_memo_category_select" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/MEMO-Zi/app/src/main/res/layout/bottom_sheet_memo_category_select.xml
+++ b/MEMO-Zi/app/src/main/res/layout/bottom_sheet_memo_category_select.xml
@@ -48,7 +48,6 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rcv_memo_category_select"
             android:layout_width="0dp"
-            android:background="@color/g_01"
             android:layout_height="0dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"

--- a/MEMO-Zi/app/src/main/res/layout/bottom_sheet_memo_category_select.xml
+++ b/MEMO-Zi/app/src/main/res/layout/bottom_sheet_memo_category_select.xml
@@ -9,8 +9,9 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:background="@color/white"
+        app:behavior_hideable="true"
         app:layout_behavior="@string/bottom_sheet_behavior">
 
         <androidx.constraintlayout.widget.Guideline
@@ -34,7 +35,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <ImageButton
-            android:id="@+id/btn_memo_category_select_cancel"
+            android:id="@+id/ib_memo_category_select_cancel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing8"
@@ -47,11 +48,22 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rcv_memo_category_select"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:background="@color/g_01"
+            android:layout_height="0dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/gl_top"
             tool:listitem="@layout/item_memo_category_select" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="20dp"
+            android:background="@color/g_04"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/rcv_memo_category_select" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/MEMO-Zi/app/src/main/res/layout/bottom_sheet_memo_category_select.xml
+++ b/MEMO-Zi/app/src/main/res/layout/bottom_sheet_memo_category_select.xml
@@ -44,6 +44,14 @@
             app:layout_constraintBottom_toTopOf="@id/gl_top"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+        <View
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:background="@color/g_03"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/gl_top"
+            />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rcv_memo_category_select"

--- a/MEMO-Zi/app/src/main/res/layout/item_memo_category_select.xml
+++ b/MEMO-Zi/app/src/main/res/layout/item_memo_category_select.xml
@@ -11,7 +11,15 @@
         android:id="@+id/layout_memo_select_category"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/g_03"
+            android:layout_marginHorizontal="@dimen/spacing6"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            />
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/gl_bottom"
             android:layout_width="wrap_content"

--- a/MEMO-Zi/app/src/main/res/layout/item_memo_category_select.xml
+++ b/MEMO-Zi/app/src/main/res/layout/item_memo_category_select.xml
@@ -8,6 +8,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_memo_select_category"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 


### PR DESCRIPTION
## 🛠 Related issue
- closed #43 

## ✏️ Work Description
- 메모 편집화면의 카테고리 선택

## 📸 Screenshot

[Screen_recording_20240305_174908.webm](https://github.com/MEMO-Zi/-AOS-MEMO-Zi/assets/75840431/149dde27-01b4-4dd0-9280-0386f7892014)


## 😅 Uncompleted Tasks
- [ ] 서버 통신 작업

## 📢 To Reviewers
비즈니스 로직 부분에서 리사이클러뷰 갱신 작업을 변경필요합니다. 추후 서버 통신하면서 변경필요해보여요 
고차함수, 프로세스 위주로 봐주시면 감사하겠습니다.

## ✅ Check List
- [x] Code/Git 컨벤션은 지켰나요?
- [x] PR올리기 전에 검토했나요?
- [ ] 코드리뷰 반영했나요?
